### PR TITLE
Update i18n.rb

### DIFF
--- a/lib/stringex/localization/backend/i18n.rb
+++ b/lib/stringex/localization/backend/i18n.rb
@@ -12,7 +12,7 @@ module Stringex
           end
 
           def locale
-            @locale || ::I18n.locale
+            @locale ||= ::I18n.locale
           end
 
           def locale=(new_locale)


### PR DESCRIPTION
Fix on gems/stringex-2.8.5/lib/stringex/localization/backend/i18n.rb:15: warning: instance variable @locale not initialized on older ruby/rails versions